### PR TITLE
Include setreference

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -79,7 +79,7 @@ class _MyHomePageState extends State<MyHomePage> {
           )
         )
         ..setAmount(152)
-		..setReference("your-transaction-reference")
+		    ..setReference("your-transaction-reference")
         ..setCurrency("GHS")
         ..setEmail("bakoambrose@gmail.com")
         ..setFirstName("Ambrose")

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -79,6 +79,7 @@ class _MyHomePageState extends State<MyHomePage> {
           )
         )
         ..setAmount(152)
+		..setReference("your-transaction-reference")
         ..setCurrency("GHS")
         ..setEmail("bakoambrose@gmail.com")
         ..setFirstName("Ambrose")


### PR DESCRIPTION
I got a **_[ERROR:flutter/lib/ui/ui_dart_state.cc(157)] Unhandled Exception: 'package:paystack_manager/paystack_pay_manager.dart': Failed assertion: line 125 pos 12: '_reference != null && _reference.isNotEmpty': is not true._** when i followed the guide on the official doc, I read through the error message and discovered that the **reference number** was missing, so i added the setReference() method, passed a string as argument and it worked.